### PR TITLE
Function "getBrightness" failing

### DIFF
--- a/lib/Twinkly.js
+++ b/lib/Twinkly.js
@@ -43,7 +43,7 @@ class Twinkly {
 
     getBrightness() {
         return this.initPromise
-            .then(() => this.requestService.getJson("led/out/brightness"))
+            .then(() => this.requestService.get("led/out/brightness"))
             .then(json => json.value);
     }
 


### PR DESCRIPTION
Thanks for this great homebridge plugin!

Following the standard configuration, I got it up and running, connected to my 2 Twinkly sets. However, in Home.app the Twinklys report as "no response". I can turn them on and off, and set brightness from Home.app as well as from Homebridge. However, the brightness status is not reported.

I did some debugging and found that the `getBrightness` function in Twinkly.js references an incorrect function from `RequestQueue`: "TypeError: this.requestService.getJson is not a function".

I forked this repo, made the appropriate change, installed in Homebridge. Works great now! The current brightness values show up in Homebridge and Home.app, as well as the Twinklys are no longer reporting as "no response" in Home.app.
