### PR TITLE
Generate UUID1 from MAC address

### DIFF
--- a/lib/Twinkly.js
+++ b/lib/Twinkly.js
@@ -36,7 +36,11 @@ class Twinkly {
         return this.requestService.get("gestalt", false)
             .then(json => {
                 this.name = json.device_name;
-                this.uuid = json.uuid;
+                if (json.uuid == "00000000-0000-0000-0000-000000000000") {
+                    this.uuid = `00000000-0000-1000-8000-${json.mac.replaceAll(":", "")}`;
+                } else {
+                    this.uuid = json.uuid
+                }
                 this.model = json.product_code;
                 this.serialNumber = json.hw_id;
                 this.ledCount = json.number_of_led;


### PR DESCRIPTION
I have three Twinkly lights. Two are `TW175SEUM06` and one is `TW175SEUP07`.

The two `TW175SEUM06` report `"uuid":"00000000-0000-0000-0000-000000000000"` and hence the plugin kept saying `Found known device` `IP address changed to` and alternating between the IPs of the two `TW175SEUM06`s.

```
[16/12/2022, 20:12:34] [Twinkly] GET http://192.168.1.71/xled/v1/gestalt
[16/12/2022, 20:12:34] [Twinkly] GET http://192.168.1.68/xled/v1/gestalt
[16/12/2022, 20:12:34] [Twinkly] Found known device: 00000000-0000-0000-0000-000000000000 @ 192.168.1.68 (Sitting room)
[16/12/2022, 20:12:34] [Twinkly] IP address changed to 192.168.1.71
[16/12/2022, 20:12:34] [Twinkly] Found unknown device: 00000000-0000-0000-0000-000000000000 @ 192.168.1.71 (Loft)
[16/12/2022, 20:12:34] [Twinkly] Found known device: 00000000-0000-0000-0000-000000000000 @ 192.168.1.71 (Loft)
[16/12/2022, 20:12:34] [Twinkly] IP address changed to 192.168.1.68
[16/12/2022, 20:12:34] [Twinkly] Found unknown device: 00000000-0000-0000-0000-000000000000 @ 192.168.1.68 (Sitting room)
```

For reference:

```
curl http://192.168.1.68/xled/v1/gestalt
{"product_name":"Twinkly","product_version":"2","hardware_version":"6","flash_size":16,"led_type":5,"led_version":"1","product_code":"TW175SEUM06","device_name":"Sitting room","uptime":"2629836","rssi":-63,"hw_id":"00b69ce6","mac":"5c:cf:7f:b6:9c:e6","uuid":"00000000-0000-0000-0000-000000000000","max_supported_led":224,"base_leds_number":175,"number_of_led":175,"led_profile":"RGB","frame_rate":18,"movie_capacity":719,"copyright":"LEDWORKS 2017","code":1000}%

curl http://192.168.1.9/xled/v1/gestalt
{"product_name":"Twinkly","product_version":"16","hardware_version":"7","flash_size":16,"led_type":6,"led_version":"1","product_code":"TW175SEUP07","device_name":"Conservatory","uptime":"2298013","rssi":-82,"hw_id":"004ffbc9","mac":"84:f3:eb:4f:fb:c9","uuid":"CE74807E-A1C1-4087-A88E-2A2D6C748898","max_supported_led":255,"base_leds_number":175,"number_of_led":175,"led_profile":"RGB","frame_rate":25,"movie_capacity":719,"copyright":"LEDWORKS 2017","code":1000}%

curl http://192.168.1.71/xled/v1/gestalt
{"product_name":"Twinkly","product_version":"2","hardware_version":"6","flash_size":16,"led_type":5,"led_version":"1","product_code":"TW175SEUM06","device_name":"Loft","uptime":"3601627","rssi":-72,"hw_id":"002438c3","mac":"a0:20:a6:24:38:c3","uuid":"00000000-0000-0000-0000-000000000000","max_supported_led":224,"base_leds_number":175,"number_of_led":175,"led_profile":"RGB","frame_rate":18,"movie_capacity":719,"copyright":"LEDWORKS 2017","code":1000}%
```

This PR generates a deterministic UUID version1 from the MAC address of the Twinkly if a nil UUID is detected.

My two `TW175SEUM06` are now uniquely identifiable and all appears to be working:

```
[16/12/2022, 20:39:45] [Twinkly] GET http://192.168.1.68/xled/v1/gestalt
[16/12/2022, 20:39:45] [Twinkly] GET http://192.168.1.71/xled/v1/gestalt
[16/12/2022, 20:39:45] [Twinkly] GET http://192.168.1.9/xled/v1/gestalt
[16/12/2022, 20:39:45] [Twinkly] Found known device: 00000000-0000-1000-8000-5ccf7fb69ce6 @ 192.168.1.68
[16/12/2022, 20:39:45] [Twinkly] Found known device: 00000000-0000-1000-8000-a020a62438c3 @ 192.168.1.71
[16/12/2022, 20:39:45] [Twinkly] Found known device: CE74807E-A1C1-4087-A88E-2A2D6C748898 @ 192.168.1.9
```